### PR TITLE
changed to order by api_key/job_id.{ext}

### DIFF
--- a/fooocusapi/utils/file_utils.py
+++ b/fooocusapi/utils/file_utils.py
@@ -22,7 +22,7 @@ from fooocusapi.utils.logger import logger
 
 
 output_dir = os.path.abspath(os.path.join(
-    os.path.dirname(__file__), '../..', 'outputs', 'files'))
+    os.path.dirname(__file__), '../..', 'outputs'))
 os.makedirs(output_dir, exist_ok=True)
 
 STATIC_SERVER_BASE = 'http://127.0.0.1:8888/files/'
@@ -43,10 +43,7 @@ def save_output_file(
     Returns:
         str of file name
     """
-    current_time = datetime.datetime.now()
-    date_string = current_time.strftime("%Y-%m-%d")
-
-    filename = os.path.join(date_string, image_name + '.' + extension)
+    filename = os.path.join(image_name + '.' + extension)
     file_path = os.path.join(output_dir, filename)
 
     if extension not in ['png', 'jpg', 'webp']:

--- a/fooocusapi/worker.py
+++ b/fooocusapi/worker.py
@@ -165,7 +165,7 @@ def process_generate(async_task: QueueTask):
             if async_task.req_param.save_name == '':
                 image_name = f"{async_task.job_id}-{str(index)}"
             else:
-                image_name = f"{async_task.req_param.save_name}-{str(index)}"
+                image_name = f"{async_task.req_param.save_name}/{async_task.job_id}-{str(index)}"
             if len(tasks) == 0:
                 img_seed = -1
                 img_meta = {}


### PR DESCRIPTION
- removed `/files` from output path.
- removed date from file path
- output is now /outputs/{api_key}/{job_id}.{extension